### PR TITLE
chore: use `chaoscenter` as pebble service name

### DIFF
--- a/3.20.0/rockcraft.yaml
+++ b/3.20.0/rockcraft.yaml
@@ -7,7 +7,7 @@ version: "3.20.0"
 base: ubuntu@24.04
 license: Apache-2.0
 services:
-  nginx:
+  chaoscenter:
     override: replace
     command: nginx -g 'daemon off;'
     startup: enabled


### PR DESCRIPTION
Contributes to fixing https://github.com/canonical/litmus-operators/issues/19