### PR TITLE
add the http_stub_status_module for nginx exporter

### DIFF
--- a/3.21.0/rockcraft.yaml
+++ b/3.21.0/rockcraft.yaml
@@ -42,6 +42,7 @@ parts:
       - --with-http_v2_module
       - --with-stream=dynamic
       - --with-http_addition_module
+      - --with-http_stub_status_module
       - --with-http_mp4_module
     override-build: |
       set -x


### PR DESCRIPTION
this is needed for the nginx exporter to be able to determine whether nginx is up or down.